### PR TITLE
Fix initialization of the sa_len and ss_len fields in struct

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1727,10 +1727,15 @@ AC_DEFINE_UNQUOTED([IKED_USER], ["$IKED_USER"],
 	[non-privileged user for privilege separation])
 AC_SUBST([IKED_USER])
 
+_prefix=`eval echo ${prefix}`
+if test x$_prefix = xNONE; then
+	_prefix=$ac_default_prefix
+fi
+
 _sysconfdir=`eval echo ${sysconfdir}`
 case $_sysconfdir in
 NONE/*)
-	_sysconfdir=`echo $_sysconfdir | sed "s~NONE~$ac_default_prefix~"` ;;
+	_sysconfdir=`echo $_sysconfdir | sed "s~NONE~$_prefix~"` ;;
 esac
 
 ikedconf=`eval echo ${_sysconfdir}/iked.conf`
@@ -2486,7 +2491,8 @@ if test "x$ZIP" != "x"; then
 	AC_DEFINE_UNQUOTED([PATH_ZIP], ["$ZIP"], [Path to ZIP binary])
 fi
 
-AC_DEFINE_UNQUOTED([PREFIX], ["$prefix"], [Root directory prefix])
+
+AC_DEFINE_UNQUOTED([PREFIX], ["$_prefix"], [Root directory prefix])
 
 AC_DEFINE([_GNU_SOURCE], [1], [Enable GNU Extensions])
 

--- a/iked/iked.c
+++ b/iked/iked.c
@@ -205,6 +205,7 @@ parent_configure(struct iked *env)
 
 	bzero(&ss, sizeof(ss));
 	ss.ss_family = AF_INET;
+	SET_SS_LEN(&ss, sizeof(struct sockaddr_in));
 
 	if ((env->sc_opts & IKED_OPT_NATT) == 0)
 		config_setsocket(env, &ss, ntohs(IKED_IKE_PORT), PROC_IKEV2);
@@ -213,6 +214,7 @@ parent_configure(struct iked *env)
 
 	bzero(&ss, sizeof(ss));
 	ss.ss_family = AF_INET6;
+	SET_SS_LEN(&ss, sizeof(struct sockaddr_in6));
 
 	if ((env->sc_opts & IKED_OPT_NATT) == 0)
 		config_setsocket(env, &ss, ntohs(IKED_IKE_PORT), PROC_IKEV2);

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -5028,8 +5028,7 @@ int
 ikev2_print_id(struct iked_id *id, char *idstr, size_t idstrlen)
 {
 	uint8_t				 buf[BUFSIZ], *ptr;
-	struct sockaddr_in		*s4;
-	struct sockaddr_in6		*s6;
+	struct sockaddr			*sa;
 	char				*str;
 	ssize_t				 len;
 	int				 i;
@@ -5061,13 +5060,11 @@ ikev2_print_id(struct iked_id *id, char *idstr, size_t idstrlen)
 
 	switch (id->id_type) {
 	case IKEV2_ID_IPV4:
-		s4 = (struct sockaddr_in *)buf;
-		s4->sin_family = AF_INET;
-		SET_STORAGE_LEN(*(struct sockaddr_storage *)s4, sizeof(*s4));
-		memcpy(&s4->sin_addr.s_addr, ptr, len);
-
-		if (print_host((struct sockaddr *)s4,
-		    idstr, idstrlen) == NULL)
+		sa = (struct sockaddr *)buf;
+		sa->sa_family = AF_INET;
+		SET_SA_LEN(sa, sizeof(struct sockaddr_in));
+		memcpy(&((struct sockaddr_in *)sa)->sin_addr, ptr, len);
+		if (print_host(sa, idstr, idstrlen) == NULL)
 			return (-1);
 		break;
 	case IKEV2_ID_FQDN:
@@ -5085,13 +5082,11 @@ ikev2_print_id(struct iked_id *id, char *idstr, size_t idstrlen)
 		free(str);
 		break;
 	case IKEV2_ID_IPV6:
-		s6 = (struct sockaddr_in6 *)buf;
-		s6->sin6_family = AF_INET6;
-		SET_STORAGE_LEN(*(struct sockaddr_storage *)s6, sizeof(*s6));
-		memcpy(&s6->sin6_addr, ptr, len);
-
-		if (print_host((struct sockaddr *)s6,
-		    idstr, idstrlen) == NULL)
+		sa = (struct sockaddr *)buf;
+		sa->sa_family = AF_INET6;
+		SET_SA_LEN(sa, sizeof(struct sockaddr_in6));
+		memcpy(&((struct sockaddr_in6 *)sa)->sin6_addr, ptr, len);
+		if (print_host(sa, idstr, idstrlen) == NULL)
 			return (-1);
 		break;
 	case IKEV2_ID_ASN1_DN:
@@ -5179,18 +5174,16 @@ ikev2_cp_setaddr(struct iked *env, struct iked_sa *sa, sa_family_t family)
 	switch (addr.addr_af) {
 	case AF_INET:
 		cfg4 = (struct sockaddr_in *)&ikecfg->cfg.address.addr;
-		in4 = (struct sockaddr_in *)&addr.addr;
-		in4->sin_family = AF_INET;
-		SET_STORAGE_LEN(*(struct sockaddr_storage *)in4, sizeof(*in4));
+		addr.addr.ss_family = AF_INET;
+		SET_SS_LEN(&addr.addr, sizeof(struct sockaddr_in));
 		mask = prefixlen2mask(ikecfg->cfg.address.addr_mask);
 		lower = ntohl(cfg4->sin_addr.s_addr & ~mask);
 		key.sa_addrpool = &addr;
 		break;
 	case AF_INET6:
 		cfg6 = (struct sockaddr_in6 *)&ikecfg->cfg.address.addr;
-		in6 = (struct sockaddr_in6 *)&addr.addr;
-		in6->sin6_family = AF_INET6;
-		SET_STORAGE_LEN(*(struct sockaddr_storage *)in6, sizeof(*in6));
+		addr.addr.ss_family = AF_INET6;
+		SET_SS_LEN(&addr.addr, sizeof(struct sockaddr_in6));
 		/* truncate prefixlen to get a 32-bit space */
 		mask = (ikecfg->cfg.address.addr_mask >= 96)
 		    ? prefixlen2mask(ikecfg->cfg.address.addr_mask - 96)
@@ -5215,11 +5208,14 @@ ikev2_cp_setaddr(struct iked *env, struct iked_sa *sa, sa_family_t family)
 		    __func__, mask, start, lower, host, upper);
 		switch (addr.addr_af) {
 		case AF_INET:
+			in4 = (struct sockaddr_in *)&addr.addr;
 			in4->sin_addr.s_addr =
 			    (cfg4->sin_addr.s_addr & mask) | htonl(host);
 			break;
 		case AF_INET6:
-			memcpy(in6, cfg6, sizeof(*in6));
+			in6 = (struct sockaddr_in6 *)&addr.addr;
+			memcpy(&in6->sin6_addr, &cfg6->sin6_addr,
+			    sizeof(in6->sin6_addr));
 			nhost = htonl(host);
 			memcpy(&in6->sin6_addr.s6_addr[12], &nhost,
 			    sizeof(uint32_t));

--- a/iked/ikev2.c
+++ b/iked/ikev2.c
@@ -4709,9 +4709,7 @@ int
 ikev2_childsa_enable(struct iked *env, struct iked_sa *sa)
 {
 	struct iked_childsa	*csa;
-#if defined (_INSTALL_IPSEC_POLICY)
 	struct iked_flow	*flow, *oflow;
-#endif
 
 	if (sa->sa_ipcomp && sa->sa_cpi_in && sa->sa_cpi_out &&
 	    ikev2_ipcomp_enable(env, sa) == -1)
@@ -4734,7 +4732,6 @@ ikev2_childsa_enable(struct iked *env, struct iked_sa *sa)
 		    print_spi(csa->csa_spi.spi, csa->csa_spi.spi_size));
 	}
 
-#if defined (_INSTALL_IPSEC_POLICY)
 	TAILQ_FOREACH(flow, &sa->sa_flows, flow_entry) {
 		if (flow->flow_loaded)
 			continue;
@@ -4756,7 +4753,6 @@ ikev2_childsa_enable(struct iked *env, struct iked_sa *sa)
 
 		log_debug("%s: loaded flow %p", __func__, flow);
 	}
-#endif
 
 	return (0);
 }

--- a/iked/ikev2_pld.c
+++ b/iked/ikev2_pld.c
@@ -1537,8 +1537,7 @@ ikev2_pld_ts(struct iked *env, struct ikev2_payload *pld,
 	struct ikev2_tsp		 tsp;
 	struct ikev2_ts			 ts;
 	size_t				 len, i;
-	struct sockaddr_in		 s4;
-	struct sockaddr_in6		 s6;
+	struct sockaddr_storage		 ss;
 	uint8_t				 buf[2][128];
 	uint8_t				*msgbuf = ibuf_data(msg->msg_data);
 
@@ -1561,36 +1560,33 @@ ikev2_pld_ts(struct iked *env, struct ikev2_payload *pld,
 		    betoh16(ts.ts_startport),
 		    betoh16(ts.ts_endport));
 
+		bzero(&ss, sizeof(ss));
 		switch (ts.ts_type) {
 		case IKEV2_TS_IPV4_ADDR_RANGE:
-			bzero(&s4, sizeof(s4));
-			s4.sin_family = AF_INET;
-			SET_STORAGE_LEN((struct sockaddr_storage)s4,
-			    sizeof(s4));
-			memcpy(&s4.sin_addr.s_addr,
+			ss.ss_family = AF_INET;
+			SET_SS_LEN(&ss, sizeof(struct sockaddr_in));
+			memcpy(&((struct sockaddr_in *)&ss)->sin_addr,
 			    msgbuf + offset + sizeof(ts), 4);
-			print_host((struct sockaddr *)&s4,
-			    (char *)buf[0], sizeof(buf[0]));
-			memcpy(&s4.sin_addr.s_addr,
+			print_host((struct sockaddr *)&ss, (char *)buf[0],
+			    sizeof(buf[0]));
+			memcpy(&((struct sockaddr_in *)&ss)->sin_addr,
 			    msgbuf + offset + sizeof(ts) + 4, 4);
-			print_host((struct sockaddr *)&s4,
-			    (char *)buf[1], sizeof(buf[1]));
+			print_host((struct sockaddr *)&ss, (char *)buf[1],
+			    sizeof(buf[1]));
 			log_debug("%s: start %s end %s", __func__,
 			    buf[0], buf[1]);
 			break;
 		case IKEV2_TS_IPV6_ADDR_RANGE:
-			bzero(&s6, sizeof(s6));
-			s6.sin6_family = AF_INET6;
-			SET_STORAGE_LEN((struct sockaddr_storage)s6,
-			    sizeof(s6));
-			memcpy(&s6.sin6_addr,
+			ss.ss_family = AF_INET6;
+			SET_SS_LEN(&ss, sizeof(struct sockaddr_in6));
+			memcpy(&((struct sockaddr_in6 *)&ss)->sin6_addr,
 			    msgbuf + offset + sizeof(ts), 16);
-			print_host((struct sockaddr *)&s6,
-			    (char *)buf[0], sizeof(buf[0]));
-			memcpy(&s6.sin6_addr,
+			print_host((struct sockaddr *)&ss, (char *)buf[0],
+			    sizeof(buf[0]));
+			memcpy(&((struct sockaddr_in6 *)&ss)->sin6_addr,
 			    msgbuf + offset + sizeof(ts) + 16, 16);
-			print_host((struct sockaddr *)&s6,
-			    (char *)buf[1], sizeof(buf[1]));
+			print_host((struct sockaddr *)&ss, (char *)buf[1],
+			    sizeof(buf[1]));
 			log_debug("%s: start %s end %s", __func__,
 			    buf[0], buf[1]);
 			break;

--- a/iked/pfkey.c
+++ b/iked/pfkey.c
@@ -255,7 +255,7 @@ pfkey_flow(int sd, uint8_t satype, uint8_t action, struct iked_flow *flow)
 		    __func__, flow->flow_src.addr_af);
 		return (-1);
 	}
-	SET_STORAGE_LEN(smask, SS_LEN(ssrc));
+	SET_SS_LEN(smask, SS_LEN(ssrc));
 
 	bzero(&sdst, sizeof(sdst));
 	bzero(&dmask, sizeof(dmask));

--- a/iked/pfkey.c
+++ b/iked/pfkey.c
@@ -255,7 +255,7 @@ pfkey_flow(int sd, uint8_t satype, uint8_t action, struct iked_flow *flow)
 		    __func__, flow->flow_src.addr_af);
 		return (-1);
 	}
-	SET_SS_LEN(smask, SS_LEN(ssrc));
+	SET_SS_LEN(&smask, SS_LEN(&ssrc));
 
 	bzero(&sdst, sizeof(sdst));
 	bzero(&dmask, sizeof(dmask));

--- a/openbsd-compat/openbsd-compat.h
+++ b/openbsd-compat/openbsd-compat.h
@@ -72,6 +72,14 @@
 # endif
 #endif
 
+#if !defined(SET_SA_LEN)
+# if defined(HAVE_STRUCT_SOCKADDR_SA_LEN)
+#  define SET_SA_LEN(sa, len)	((sa)->sa_len = (len))
+# else
+#  define SET_SA_LEN(sa, len)	(void)0
+# endif
+#endif
+
 /* From OpenBGPD portable */
 #if !defined(SS_LEN)
 # if defined(HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN)
@@ -81,18 +89,13 @@
 # endif
 #endif
 
-#ifdef HAVE_SS_LEN
-# define STORAGE_LEN(X) ((X).ss_len)
-# define SET_STORAGE_LEN(X, Y) do { STORAGE_LEN(X) = (Y); } while(0)
-#elif defined(HAVE___SS_LEN)
-# define STORAGE_LEN(X) ((X).__ss_len)
-# define SET_STORAGE_LEN(X, Y) do { STORAGE_LEN(X) = (Y); } while(0)
-#else
-# define STORAGE_FAMILY(x) ((x).ss_family)
-# define STORAGE_LEN(X) (STORAGE_FAMILY(X) == AF_INET ? sizeof(struct sockaddr_in) : sizeof(struct sockaddr_in6))
-# define SET_STORAGE_LEN(X, Y) (void) 0
+#if !defined(SET_SS_LEN)
+# if defined(HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN)
+#  define SET_SS_LEN(ss, len)	((ss)->ss_len = (len))
+# else
+#  define SET_SS_LEN(ss, len)	SET_SA_LEN((struct sockaddr *)(ss), len)
+# endif
 #endif
-
 
 #ifndef HAVE_CLOSEFROM
 void closefrom(int);


### PR DESCRIPTION
sockaddr and struct sockaddr_storage (resp):
-  Fix openbsd-compat.h and replace SET_STORAGE_LEN with
  SET_SA_LEN and SET_SS_LEN. Remove the unused STORAGE_LEN
  and now unused STORAGE_FAMILY.
-  Make the definition of SET_SA_LEN dependent upon
  HAVE_STRUCT_SOCKADDR_SA_LEN. if HAVE_STRUCT_SOCKADDR_SA_LEN
  is not defined, expand SET_SA_LEN to void.
-  Make the definition of SET_SS_LEN dependent upon
  HAVE_STRUCT_SOCKADDR_STORAGE_SS_LEN. If the latter is not
  defined, expand SET_SS_LEN to SET_SA_LEN. This to avoid
  compatibility problems between ss_len and __ss_len.
-  Avoid excessive back and forth casting and use sockaddr or
  sockaddr_storage as much as possible.

While here, eliminate the af field from struct ipsec_addr_wrap.
This makes sure that the ss_family field in address is always
properly initialized. Redundant variables tend to have that
effect.

This fixes setting up SAs on FreeBSD and presumably any OS that
have sa_len and ss_len.
